### PR TITLE
correctly log the ApplicationName value

### DIFF
--- a/src/Elmah.AzureTableStorage/AzureTableStorageErrorLog.cs
+++ b/src/Elmah.AzureTableStorage/AzureTableStorageErrorLog.cs
@@ -118,6 +118,7 @@ namespace Elmah.AzureTableStorage
             // This obviously has a performance hit, but since users are usually looking at the latest ones, this may be OK for most scenarios.
             var errorEntities = _tableContext
                 .CreateQuery<ElmahEntity>(TableName)
+                .Where(e => e.ApplicationName == ApplicationName)
                 .AsTableServiceQuery(_tableContext)
                 .Take((pageIndex + 1) * pageSize)
                 .ToList()


### PR DESCRIPTION
The ErrorLog's ApplicationName value should be passed to the ElmahEntity's ApplicationName property, and GetErrors should filter by ApplicationName.

You can reference the SqlErrorLog.cs file from the ELMAH project:  
http://code.google.com/p/elmah/source/browse/src/Elmah.SqlServer/SqlErrorLog.cs
