### PR TITLE
Bug fix: base64 encoded RowKey and PartitionKey now safe

### DIFF
--- a/src/Elmah.AzureTableStorage/AzureHelper.cs
+++ b/src/Elmah.AzureTableStorage/AzureHelper.cs
@@ -29,12 +29,12 @@ namespace Elmah.AzureTableStorage
     {
         internal static string EncodeAzureKey(string key)
         {
-            return key == null ? null : Convert.ToBase64String(Encoding.UTF8.GetBytes(key));
+            return string.IsNullOrEmpty(key) ? null : Convert.ToBase64String(Encoding.UTF8.GetBytes(key)).Replace("/", "_");
         }
 
         internal static string DecodeAzureKey(string encodedKey)
         {
-            return encodedKey == null ? null : Encoding.UTF8.GetString(Convert.FromBase64String(encodedKey));
+            return string.IsNullOrEmpty(encodedKey) ? null : Encoding.UTF8.GetString(Convert.FromBase64String(encodedKey)).Replace("_", "/");
         }
     }
 }

--- a/src/Elmah.AzureTableStorage/Elmah.AzureTableStorage.csproj
+++ b/src/Elmah.AzureTableStorage/Elmah.AzureTableStorage.csproj
@@ -31,32 +31,39 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah">
+    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=3.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\WindowsAzure.Storage.3.0.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\WindowsAzure.Storage.4.2.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -75,7 +82,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Elmah.AzureTableStorage/ElmahEntity.cs
+++ b/src/Elmah.AzureTableStorage/ElmahEntity.cs
@@ -4,7 +4,6 @@ using System;
 
 namespace Elmah.AzureTableStorage
 {
-    [DataServiceKey("PartitionKey", "RowKey")]
     public class ElmahEntity : TableEntity
     {
         public ElmahEntity()

--- a/src/Elmah.AzureTableStorage/packages.config
+++ b/src/Elmah.AzureTableStorage/packages.config
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah" version="1.2.2" targetFramework="net40" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net40" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net40" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net40" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net40" />
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net40" />
-  <package id="WindowsAzure.Storage" version="3.0.3.0" targetFramework="net40" />
+  <package id="WindowsAzure.Storage" version="4.2.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Azure table storage do not support the '/' character in its RowKey and
PartitionKey. Hence we need to replace any occurence before inserting