### PR TITLE
Application settings based custom application name and table name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.user
 obj/
 bin/
+.vs/

--- a/README.md
+++ b/README.md
@@ -46,9 +46,23 @@ Isolate per application in a single Elmah store
     <errorLog type="Elmah.AzureTableStorage.AzureTableStorageErrorLog, Elmah.AzureTableStorage" 
         connectionString="UseDevelopmentStorage=true" applicationName="MyApp" />
 
+By application setting:
+
+    <errorLog type="Elmah.AzureTableStorage.AzureTableStorageErrorLog, Elmah.AzureTableStorage" 
+        connectionString="UseDevelopmentStorage=true" applicationNameAppKey="ApplicationName" />
+
+Make sure you add an element under the `appSettings` element.
+
 ### Table Name
 
 Set a custom table name (defaults to "Elmah"):
 
     <errorLog type="Elmah.AzureTableStorage.AzureTableStorageErrorLog, Elmah.AzureTableStorage" 
         connectionString="UseDevelopmentStorage=true" tableName="MyCustomElmahTable" />
+
+By application setting:
+
+    <errorLog type="Elmah.AzureTableStorage.AzureTableStorageErrorLog, Elmah.AzureTableStorage" 
+        connectionString="UseDevelopmentStorage=true" tableNameAppKey="ElmahTableName" />
+
+Make sure you add an element under the `appSettings` element.

--- a/src/Elmah.AzureTableStorage/AzureTableStorageErrorLog.cs
+++ b/src/Elmah.AzureTableStorage/AzureTableStorageErrorLog.cs
@@ -44,9 +44,11 @@ namespace Elmah.AzureTableStorage
             // Get custom table name for storage and validate
             //
 
-            var tableName = config.Find("tableName", DefaultTableName);
+            var tableName = ElmahHelper.GetTableName(config);
+            if (tableName.Length == 0)
+                tableName = DefaultTableName;
 
-            if(!Regex.IsMatch(tableName, TableValidationRegex))
+            if (!Regex.IsMatch(tableName, TableValidationRegex))
                 throw new ApplicationException("Name for table in Azure Table Storage is not a valid name.");
 
             var cloudStorageAccount = CloudStorageAccount.Parse(connectionString);
@@ -59,7 +61,7 @@ namespace Elmah.AzureTableStorage
             // per-application isolation over a single store.
             //
 
-            var appName = config.Find("applicationName", string.Empty);
+            var appName = ElmahHelper.GetApplicationName(config);
 
             if (appName.Length > MaxAppNameLength)
             {

--- a/src/Elmah.AzureTableStorage/ElmahHelper.cs
+++ b/src/Elmah.AzureTableStorage/ElmahHelper.cs
@@ -57,5 +57,45 @@ namespace Elmah.AzureTableStorage
                  ? CloudConfigurationManager.GetSetting(connectionStringAppKey)
                  : string.Empty;
         }
+
+        public static string GetApplicationName(IDictionary config)
+        {
+            // Check for application name
+            var applicationName = config.Find("applicationName", string.Empty);
+            if (applicationName.Length > 0)
+                return applicationName;
+
+            // If not found then check for <appSettings> Key
+            var applicationNameAppKey = config.Find("applicationNameAppKey", string.Empty);
+            if (applicationNameAppKey.Length > 0)
+            {
+                applicationName = CloudConfigurationManager.GetSetting(applicationNameAppKey);
+
+                if (applicationName == null)
+                    return string.Empty;
+            }
+
+            return applicationName;
+        }
+
+        public static string GetTableName(IDictionary config)
+        {
+            // Check for table name
+            var tableName = config.Find("tableName", string.Empty);
+            if (tableName.Length > 0)
+                return tableName;
+
+            // If not found then check for <appSettings> Key
+            var tableNameAppKey = config.Find("tableNameAppKey", string.Empty);
+            if (tableNameAppKey.Length > 0)
+            {
+                tableName = CloudConfigurationManager.GetSetting(tableNameAppKey);
+
+                if (tableName == null)
+                    return string.Empty;
+            }
+
+            return tableName;
+        }
     }
 }


### PR DESCRIPTION
Added support for application settings based custom application name and table name. Also updated README for how to use guide.

Use case: If you are using Azure app service, you can use a different table for each slot by simply setting application setting in the Azure portal. This can be also useful if you are replacing application settings in CI/CD pipelines.